### PR TITLE
Fix regression in QR code creation

### DIFF
--- a/src/components/qrcode/CreateQRCode.vue
+++ b/src/components/qrcode/CreateQRCode.vue
@@ -68,12 +68,25 @@ const props = defineProps({
 
 const avatarUrl = ref("")
 
+watch(
+  () => props.hiveAccname,
+  async (newVal) => {
+    avatarUrl.value = await useHiveAvatarBlob({
+      hiveAccname: newVal,
+      size: "small",
+      reason: "qr-code",
+    })
+  }
+)
+
 onMounted(async () => {
   avatarUrl.value = await useHiveAvatarBlob({
     hiveAccname: props.hiveAccname,
     size: "small",
     reason: "qr-code",
   })
+
+  console.log("avatarUrl", avatarUrl.value)
   qrTextPage.value = props.qrText
   await newQRCode()
 })


### PR DESCRIPTION
When the hiveAccname changes after the QR code is created, the
Hive avatar is not updated. This is because the QR code is created
in the mounted() method and the hiveAccname is not available at
that time.

Adds a watcher to the hiveAccname and recreates the QR code when
it changes.

Signed-off-by: Brian of London (Dot) <brian@v4v.app>
