### PR TITLE
fix: new tab / reload not showing KeepSats for keychain accounts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "v4vapp",
-  "version": "2.6.1-alpha",
+  "version": "2.6.1.alpha.0",
   "description": "V4V.app Value 4 Value Hive Lightning Bridge",
   "productName": "V4V App",
   "author": "Brian of London (Dot) <brian@v4v.app>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "v4vapp",
-  "version": "2.6.1.alpha.0",
+  "version": "2.6.1.alpha.1",
   "description": "V4V.app Value 4 Value Hive Lightning Bridge",
   "productName": "V4V App",
   "author": "Brian of London (Dot) <brian@v4v.app>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "v4vapp",
-  "version": "2.6.0",
+  "version": "2.6.1-alpha",
   "description": "V4V.app Value 4 Value Hive Lightning Bridge",
   "productName": "V4V App",
   "author": "Brian of London (Dot) <brian@v4v.app>",

--- a/src/boot/axios.js
+++ b/src/boot/axios.js
@@ -210,7 +210,21 @@ const refreshInterceptor = async (error) => {
         if (!affectedUser) affectedUser = storeUser?.currentUser
 
         if (storeUser && affectedUser) {
-          if (typeof storeUser.logoutUser === "function") {
+          const affectedUserObj = storeUser.users?.[affectedUser]
+          const isPureKeychain = affectedUserObj && !affectedUserObj.authKey
+
+          if (isPureKeychain) {
+            // For pure keychain accounts, a failed refresh (expired short token) should
+            // not remove the account from the user's list. Just clear the in-memory token.
+            // The user can re-trigger keychain when they need a fresh session.
+            console.log(
+              "[AUTH-DEBUG] Refresh failed for pure keychain account — not logging out (short token simply expired). Account remains in list.",
+              affectedUser,
+            )
+            if (storeUser.accessTokens) {
+              delete storeUser.accessTokens[affectedUser]
+            }
+          } else if (typeof storeUser.logoutUser === "function") {
             await storeUser.logoutUser(affectedUser)
           } else if (typeof storeUser.logout === "function") {
             // Fallback: only logout current if we can't do better

--- a/src/boot/axios.js
+++ b/src/boot/axios.js
@@ -179,6 +179,9 @@ const refreshInterceptor = async (error) => {
           if (storeUser && typeof storeUser.setAccessToken === "function") {
             storeUser.setAccessToken(newToken, tokenOwner)
           }
+          if (storeUser && tokenOwner) {
+            storeUser.clearReauthNeeded(tokenOwner)
+          }
         } catch (e) {
           // non-fatal
         }
@@ -224,7 +227,9 @@ const refreshInterceptor = async (error) => {
             if (storeUser.accessTokens) {
               delete storeUser.accessTokens[affectedUser]
             }
+            storeUser.markReauthNeeded(affectedUser)
           } else if (typeof storeUser.logoutUser === "function") {
+            storeUser.markReauthNeeded(affectedUser)
             await storeUser.logoutUser(affectedUser)
           } else if (typeof storeUser.logout === "function") {
             // Fallback: only logout current if we can't do better

--- a/src/components/hive/CreditCard.vue
+++ b/src/components/hive/CreditCard.vue
@@ -76,6 +76,19 @@
             </div>
             <div v-if="storeUser.loginType === 'hive'" class="text-subtitle2">
               {{ storeUser.hiveAccname }}@v4v.app
+              <q-icon
+                v-if="storeUser.currentReauthNeeded"
+                name="warning"
+                color="warning"
+                size="0.85rem"
+                class="q-ml-xs"
+                style="vertical-align: middle;"
+              >
+                <q-tooltip>
+                  Refresh failed for this account.<br>
+                  Re-authenticate (Keychain / Passkey) to restore KeepSats balances and full access.
+                </q-tooltip>
+              </q-icon>
             </div>
           </div>
 

--- a/src/components/hive/CreditCard.vue
+++ b/src/components/hive/CreditCard.vue
@@ -50,6 +50,37 @@
       style="position: absolute; top: 30%; left: 8%"
     />
 
+    <!-- Prominent re-auth warning on the card body (near where the reload spinner appears).
+         Only shown after an actual refresh failure. Click to open the auth flow for this account. -->
+    <div
+      v-if="storeUser.currentReauthNeeded && !storeUser.dataLoading"
+      class="reauth-warning cursor-pointer"
+      style="
+        position: absolute;
+        top: 24%;
+        left: 7%;
+        z-index: 20;
+        background: rgba(0, 0, 0, 0.45);
+        border-radius: 50%;
+        padding: 4px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      "
+      @click="triggerReauth"
+    >
+      <q-icon
+        name="warning"
+        color="orange"
+        size="2.6rem"
+      >
+        <q-tooltip>
+          Refresh failed for this account.<br>
+          Click to re-authenticate @{{ storeUser.currentUser }}
+        </q-tooltip>
+      </q-icon>
+    </div>
+
     <q-card-section
       v-if="storeUser.currentUser"
       class="credit-card-strip absolute-bottom q-py-xs q-px-sm text-subtitle2 text-left"
@@ -76,19 +107,6 @@
             </div>
             <div v-if="storeUser.loginType === 'hive'" class="text-subtitle2">
               {{ storeUser.hiveAccname }}@v4v.app
-              <q-icon
-                v-if="storeUser.currentReauthNeeded"
-                name="warning"
-                color="warning"
-                size="0.85rem"
-                class="q-ml-xs"
-                style="vertical-align: middle;"
-              >
-                <q-tooltip>
-                  Refresh failed for this account.<br>
-                  Re-authenticate (Keychain / Passkey) to restore KeepSats balances and full access.
-                </q-tooltip>
-              </q-icon>
             </div>
           </div>
 
@@ -214,6 +232,7 @@ import HbdLogoIcon from "../utils/HbdLogoIcon.vue"
 import { tidyNumber } from "src/use/useUtils"
 import { useI18n } from "vue-i18n"
 import { useCoingeckoStore } from "src/stores/storeCoingecko"
+import { useKeychainLoginFlow } from "src/use/useKeychain"
 const storeCoingecko = useCoingeckoStore()
 
 // import { useLocalCurrencyBalances } from "src/use/useCurrencyCalc"
@@ -330,6 +349,43 @@ async function scheduleUpdate() {
   await storeUser.update(false)
   // Schedule the next update after 5 minutes
   timeoutId = setTimeout(scheduleUpdate, 5 * 60 * 1000)
+}
+
+/**
+ * Trigger re-authentication for the current account when the warning icon is clicked.
+ * For keychain accounts this directly starts the Keychain signature flow.
+ * For passkey/webauthn it directs the user (the passkey flow is usually initiated from the menu).
+ */
+async function triggerReauth() {
+  if (!storeUser.currentUser) return
+
+  const acc = storeUser.currentUser
+  storeUser.clearReauthNeeded(acc)
+
+  const isWebauthn = storeUser.authKey === 'webauthn'
+
+  if (isWebauthn) {
+    q.notify({
+      message: `Please re-login with Passkey for @${acc} using the side menu`,
+      color: 'info',
+      timeout: 6000,
+    })
+    return
+  }
+
+  // Keychain (or other hive login) - start the flow directly
+  try {
+    const hiveAccObj = { value: acc }
+    const keyType = storeUser.user?.keySelected || 'Active'
+    const props = { keyType }
+    await useKeychainLoginFlow(hiveAccObj, props)
+  } catch (err) {
+    console.error('Re-auth keychain flow error:', err)
+    q.notify({
+      message: `Failed to start re-auth for @${acc}. Please try from the menu.`,
+      color: 'negative',
+    })
+  }
 }
 
 const lightDark = computed(() => {

--- a/src/stores/storeUser.js
+++ b/src/stores/storeUser.js
@@ -540,9 +540,15 @@ export const useStoreUser = defineStore("useStoreUser", {
       // called once from the HiveLogin component.
       console.log("Store initialized")
 
-      // Because we are invalidating all existing logins for the new auth model,
-      // aggressively remove any old persisted apiTokens from localStorage.
-      // This is a one-time migration step.
+      // Auth hardening migration:
+      // - For accounts that used modern login paths (authKey set, e.g. webauthn/passkey),
+      //   we never persist tokens — they rely on short-lived in-memory + HttpOnly refresh cookie.
+      // - For pure legacy keychain accounts (!authKey), we allow the *short-lived* access token
+      //   received on their last keychain login to remain persisted. This restores the previous
+      //   behaviour where opening a new tab immediately shows KeepSats balances for keychain
+      //   accounts (for the remaining lifetime of that short token).
+      // We only strip apiToken on accounts that have authKey (the dangerous long-lived ones
+      // from the old model, or any that went through the new cookie-based paths).
       let strippedAny = false
       const accountsWithOldTokens = []
 
@@ -551,12 +557,13 @@ export const useStoreUser = defineStore("useStoreUser", {
         if (!user.loginType) {
           user.loginType = "hive"
         }
-        if (user.apiToken) {
+        if (user.apiToken && user.authKey) {
+          // Only strip for modern/cookie-capable accounts
           accountsWithOldTokens.push(userId)
           console.warn(
-            "[AUTH-DEBUG] Found OLD apiToken on account:",
+            "[AUTH-DEBUG] Found OLD apiToken on modern auth account:",
             userId,
-            "— will strip it",
+            "— will strip it (keychain accounts keep their short token for cross-tab use)",
           )
           delete user.apiToken
           strippedAny = true
@@ -565,7 +572,7 @@ export const useStoreUser = defineStore("useStoreUser", {
 
       if (strippedAny) {
         console.info(
-          "[auth] Stripped old persisted access tokens (full re-login required after auth hardening)",
+          "[auth] Stripped old persisted access tokens for modern auth accounts",
         )
         console.warn(
           "[AUTH-DEBUG] Accounts that had old tokens stripped:",
@@ -573,7 +580,7 @@ export const useStoreUser = defineStore("useStoreUser", {
         )
       } else {
         console.log(
-          "[AUTH-DEBUG] No old apiToken fields found in persisted users during initialize().",
+          "[AUTH-DEBUG] No old apiToken fields stripped during initialize (keychain short tokens are intentionally kept for new-tab UX).",
         )
       }
 
@@ -585,11 +592,26 @@ export const useStoreUser = defineStore("useStoreUser", {
         "[DEBUG-KeepSats] accessTokens after stripping:",
         JSON.stringify(this.accessTokens),
       )
-      if (accountsWithOldTokens.length > 0) {
-        console.warn(
-          "[DEBUG-KeepSats] Accounts that lost their apiToken will skip KeepSats fetches until they re-login or get a fresh token via refresh.",
-        )
+
+      // For pure keychain accounts (!authKey), seed the in-memory accessTokens map
+      // from any persisted short-lived apiToken. This makes new tabs / reloads
+      // immediately able to fetch KeepSats for the current keychain user, restoring
+      // the pre-hardening UX for those accounts (token is short-lived, so it will
+      // naturally stop working after backend expiry).
+      for (const userId in this.users) {
+        const user = this.users[userId]
+        if (!user.authKey && user.apiToken && !this.accessTokens[userId]) {
+          this.accessTokens[userId] = user.apiToken
+          console.log(
+            "[AUTH-DEBUG] Seeded in-memory access token for keychain account from persisted short token:",
+            userId,
+          )
+          if (userId === this.currentUser) {
+            apiLogin.defaults.headers.common["Authorization"] = `Bearer ${user.apiToken}`
+          }
+        }
       }
+
       // =====================================================
       // END DEBUG PATCH
       // =====================================================

--- a/src/stores/storeUser.js
+++ b/src/stores/storeUser.js
@@ -183,6 +183,11 @@ export const useStoreUser = defineStore("useStoreUser", {
     // long-lived JWTs in localStorage (major XSS hardening).
     // Tokens here only live for the current browser session.
     accessTokens: {},
+
+    // Tracks accounts for which a recent /auth/refresh attempt failed.
+    // Used to show a minimal, non-intrusive re-auth notifier on CreditCard
+    // **only** when an actual refresh failure occurred (not on every keychain load).
+    reauthNeeded: {},
   }),
 
   getters: {
@@ -249,6 +254,16 @@ export const useStoreUser = defineStore("useStoreUser", {
     numUsers() {
       console.debug("numUsers", Object.keys(this.users).length)
       return Object.keys(this.users).length
+    },
+
+    /**
+     * True when the *current* account had a refresh failure (cookie or short token expired).
+     * This is the signal for showing a minimal re-auth notifier on CreditCard.
+     * It is only set on actual refresh failure paths, not on normal keychain "no token on load".
+     */
+    currentReauthNeeded() {
+      if (!this.currentUser) return false
+      return !!this.reauthNeeded[this.currentUser]
     },
     /**
      * Determines the login method for the current user.
@@ -840,6 +855,7 @@ export const useStoreUser = defineStore("useStoreUser", {
 
         this.users[hiveAccname] = newUser
         this.currentUser = hiveAccname
+        this.clearReauthNeeded(hiveAccname)   // successful login clears any prior reauth flag
         if (hiveDetails) {
           this.currentDetails = hiveDetails
           this.currentProfile = hiveDetails.profile
@@ -970,6 +986,7 @@ export const useStoreUser = defineStore("useStoreUser", {
             }
 
             this.accessTokens[owner] = newToken
+            this.clearReauthNeeded(owner)   // successful restore clears any reauth flag
             if (owner === this.currentUser) {
               apiLogin.defaults.headers.common["Authorization"] = `Bearer ${newToken}`
             }
@@ -1097,6 +1114,27 @@ export const useStoreUser = defineStore("useStoreUser", {
       this.currentDetails = null
       this.currentProfile = null
       this.currentKeepSats = null
+      this.reauthNeeded = {}
+    },
+
+    /**
+     * Mark that the last refresh attempt for this account failed.
+     * This is used to drive a minimal, design-safe notifier on the CreditCard
+     * **only** when an actual refresh failure occurred.
+     */
+    markReauthNeeded(hiveAccname) {
+      if (hiveAccname) {
+        this.reauthNeeded[hiveAccname] = true
+      }
+    },
+
+    /**
+     * Clear the re-auth needed flag (called on successful login or successful token restore).
+     */
+    clearReauthNeeded(hiveAccname) {
+      if (hiveAccname) {
+        delete this.reauthNeeded[hiveAccname]
+      }
     },
 
     async bech32Address(currency = "hive") {


### PR DESCRIPTION
- Stop stripping persisted short apiToken for pure keychain accounts (!authKey). These tokens are short-lived by design; allowing them to survive to new tabs restores the previous immediate-balance UX for multi-keychain users.
- On initialize, seed accessTokens + Authorization header from any persisted short token for keychain accounts so updateSatsBalance succeeds immediately.
- Soften interceptor: failed refresh on a pure keychain account (expired short token) no longer calls logoutUser — the account stays in the list.
- Cookie / authKey accounts remain fully non-persisted + cookie-restorable only.

This fixes the reported 'new tab with keychain accounts does not fetch balance on first load' while preserving the security hardening for modern login paths.

Branch: fix/reload-in-new-tab-not-fetching-balance