### PR TITLE
feat(frontend): reduce ensureAccessToken spam when cookie belongs to another account

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "v4vapp",
-  "version": "2.6.2.alpha.0",
+  "version": "2.6.2.alpha.2",
   "description": "V4V.app Value 4 Value Hive Lightning Bridge",
   "productName": "V4V App",
   "author": "Brian of London (Dot) <brian@v4v.app>",

--- a/src/boot/axios.js
+++ b/src/boot/axios.js
@@ -168,14 +168,24 @@ const refreshInterceptor = async (error) => {
           console.log("[AUTH-DEBUG] Silent refresh token owner (from JWT):", tokenOwner)
         }
 
-        // Update default headers on BOTH instances (global header is for "whoever we just authed as")
-        api.defaults.headers.common["Authorization"] = `Bearer ${newToken}`
-        apiLogin.defaults.headers.common["Authorization"] = `Bearer ${newToken}`
-
-        // Best-effort store update — pass the real owner so it is keyed correctly in accessTokens.
+        // Only stomp the global Authorization header if the token we just got
+        // is for the *current* user in the UI. Otherwise we would send
+        // brianoflondon's token on calls that the UI thinks are for v4vapp-test.
+        const { useStoreUser } = await import("src/stores/storeUser")
+        let storeUser = null
         try {
-          const { useStoreUser } = await import("src/stores/storeUser")
-          const storeUser = useStoreUser()
+          storeUser = useStoreUser()
+        } catch {}
+
+        const shouldSetGlobalHeader = !tokenOwner || tokenOwner === storeUser?.currentUser
+
+        if (shouldSetGlobalHeader) {
+          api.defaults.headers.common["Authorization"] = `Bearer ${newToken}`
+          apiLogin.defaults.headers.common["Authorization"] = `Bearer ${newToken}`
+        }
+
+        // Always store the token under the correct owner in the map.
+        try {
           if (storeUser && typeof storeUser.setAccessToken === "function") {
             storeUser.setAccessToken(newToken, tokenOwner)
           }

--- a/src/components/hive/CreditCard.vue
+++ b/src/components/hive/CreditCard.vue
@@ -75,8 +75,8 @@
         size="2.6rem"
       >
         <q-tooltip>
-          Refresh failed for this account.<br>
-          Click to re-authenticate @{{ storeUser.currentUser }}
+          Session problem for @{{ storeUser.currentUser }}.<br>
+          Tap to log back in with Passkey
         </q-tooltip>
       </q-icon>
     </div>
@@ -233,6 +233,7 @@ import { tidyNumber } from "src/use/useUtils"
 import { useI18n } from "vue-i18n"
 import { useCoingeckoStore } from "src/stores/storeCoingecko"
 import { useKeychainLoginFlow } from "src/use/useKeychain"
+import { usePasskeyLogin } from "src/use/usePasskeys"
 const storeCoingecko = useCoingeckoStore()
 
 // import { useLocalCurrencyBalances } from "src/use/useCurrencyCalc"
@@ -352,9 +353,13 @@ async function scheduleUpdate() {
 }
 
 /**
- * Trigger re-authentication for the current account when the warning icon is clicked.
- * For keychain accounts this directly starts the Keychain signature flow.
- * For passkey/webauthn it directs the user (the passkey flow is usually initiated from the menu).
+ * Trigger re-authentication for the current account.
+ * - For webauthn/passkey accounts: asks for confirmation then triggers the passkey flow directly.
+ * - For keychain accounts: starts the keychain signature flow.
+ *
+ * This is called when the user taps the warning icon on the CreditCard,
+ * or can be called programmatically when we detect a refresh/auth failure
+ * for the current account.
  */
 async function triggerReauth() {
   if (!storeUser.currentUser) return
@@ -365,15 +370,48 @@ async function triggerReauth() {
   const isWebauthn = storeUser.authKey === 'webauthn'
 
   if (isWebauthn) {
-    q.notify({
-      message: `Please re-login with Passkey for @${acc} using the side menu`,
-      color: 'info',
-      timeout: 6000,
+    // Ask the user before popping the passkey prompt (good UX on mobile)
+    q.dialog({
+      title: 'Session expired',
+      message: `Your passkey session for @${acc} needs to be refreshed. Log back in now?`,
+      cancel: true,
+      persistent: true,
+    }).onOk(async () => {
+      try {
+        const result = await usePasskeyLogin(acc)
+        if (result.success) {
+          await storeUser.login(
+            acc,
+            'active',
+            'webauthn',
+            null,
+            null,
+            result.token,
+            'hive'
+          )
+          q.notify({
+            message: 'Re-authenticated successfully with Passkey',
+            color: 'positive',
+            timeout: 3000,
+          })
+        } else {
+          q.notify({
+            message: `Passkey re-auth failed: ${result.message || 'Unknown error'}`,
+            color: 'negative',
+          })
+        }
+      } catch (err) {
+        console.error('Passkey re-auth error:', err)
+        q.notify({
+          message: 'Failed to start passkey re-authentication',
+          color: 'negative',
+        })
+      }
     })
     return
   }
 
-  // Keychain (or other hive login) - start the flow directly
+  // Keychain (or other non-passkey hive login)
   try {
     const hiveAccObj = { value: acc }
     const keyType = storeUser.user?.keySelected || 'Active'
@@ -382,7 +420,7 @@ async function triggerReauth() {
   } catch (err) {
     console.error('Re-auth keychain flow error:', err)
     q.notify({
-      message: `Failed to start re-auth for @${acc}. Please try from the menu.`,
+      message: `Failed to start re-auth for @${acc}. Please try from the side menu.`,
       color: 'negative',
     })
   }

--- a/src/stores/storeUser.js
+++ b/src/stores/storeUser.js
@@ -748,6 +748,20 @@ export const useStoreUser = defineStore("useStoreUser", {
         if (answer == null) {
           return null
         }
+
+        // Critical safety guard against cross-user data pollution
+        // (the root cause of "shows brian's balance while on v4vapp-test" after resume/switch).
+        if (answer.hive_accname && answer.hive_accname !== this.currentUser) {
+          console.error(
+            "[AUTH-DEBUG] CRITICAL MISMATCH: Received keepsats data for the wrong user!",
+            "currentUser:", this.currentUser,
+            "response.hive_accname:", answer.hive_accname,
+            "This almost always means the Authorization header contained a token for a different account (cookie owner vs UI currentUser)."
+          );
+          // Do NOT update currentKeepSats with data that belongs to someone else.
+          return null;
+        }
+
         this.currentKeepSats = answer
         console.log(
           "[DEBUG-KeepSats] Successfully fetched and set currentKeepSats for",
@@ -883,6 +897,9 @@ export const useStoreUser = defineStore("useStoreUser", {
         this.dataLoading = true
         if (hiveAccname in this.users) {
           this.currentUser = hiveAccname
+          // Immediately clear stale balance data from the previous user.
+          // The next update() will fetch fresh data (or fail cleanly).
+          this.currentKeepSats = null
           this.apiTokenSet(hiveAccname)
           this.expireCheck()
 

--- a/src/stores/storeUser.js
+++ b/src/stores/storeUser.js
@@ -188,6 +188,13 @@ export const useStoreUser = defineStore("useStoreUser", {
     // Used to show a minimal, non-intrusive re-auth notifier on CreditCard
     // **only** when an actual refresh failure occurred (not on every keychain load).
     reauthNeeded: {},
+
+    // Simple per-account memory to avoid spamming /auth/refresh when the
+    // browser's current HttpOnly cookie belongs to a *different* account
+    // than the one the UI currently has selected as currentUser.
+    // This directly addresses the repeated ensureAccessToken spam for
+    // webauthn accounts like v4vapp-test when another account's cookie is active.
+    lastCookieRestore: {}, // { [hiveAccname]: { ts: number, owner: string | null } }
   }),
 
   getters: {
@@ -968,6 +975,18 @@ export const useStoreUser = defineStore("useStoreUser", {
       if (!target) return null
       if (this.accessTokens[target]) return this.accessTokens[target]
 
+      // Anti-spam: if we recently tried to restore a cookie for this exact account
+      // and it returned a *different* owner (meaning the browser cookie belongs
+      // to someone else right now), don't hammer /auth/refresh on every update().
+      const recent = this.lastCookieRestore[target]
+      const THIRTY_SECONDS = 30_000
+      if (recent && Date.now() - recent.ts < THIRTY_SECONDS) {
+        if (recent.owner && recent.owner !== target) {
+          // We know the current cookie can't help this account right now.
+          return null
+        }
+      }
+
       // If a cookie restore is already in flight, wait for it instead of starting
       // a second identical POST /auth/refresh. All early callers (CreditCard mount,
       // initialize, watchers, etc.) will get the same result.
@@ -999,6 +1018,11 @@ export const useStoreUser = defineStore("useStoreUser", {
 
             this.accessTokens[owner] = newToken
             this.clearReauthNeeded(owner)   // successful restore clears any reauth flag
+
+            // Record what we actually got so we can avoid spamming the same
+            // useless /auth/refresh for a different currentUser on the next update().
+            this.lastCookieRestore[target] = { ts: Date.now(), owner }
+
             if (owner === this.currentUser) {
               apiLogin.defaults.headers.common["Authorization"] = `Bearer ${newToken}`
             }
@@ -1017,6 +1041,7 @@ export const useStoreUser = defineStore("useStoreUser", {
             target,
             "— account will need explicit re-login if it has no other token"
           )
+          this.lastCookieRestore[target] = { ts: Date.now(), owner: null }
         }
         return null
       })()

--- a/src/stores/storeUser.js
+++ b/src/stores/storeUser.js
@@ -236,14 +236,15 @@ export const useStoreUser = defineStore("useStoreUser", {
     },
     apiToken() {
       if (!this.currentUser) return null
-      // Prefer the non-persisted in-memory token (new hardened model)
+      // Strictly return only a token that belongs to the currentUser.
+      // Never return a token that was restored for a different account via the
+      // HttpOnly cookie (this was causing the "wrong balance after switch" bug).
       if (this.accessTokens[this.currentUser]) {
         return this.accessTokens[this.currentUser]
       }
-      // Fallback to old persisted location (will be removed after full migration)
-      const u = this._currentHiveUser
-      if (!u?.apiToken) return null
-      return u.apiToken
+      // No fallback to old persisted apiToken for the current user if it doesn't
+      // match what we have in the in-memory map for this exact account.
+      return null
     },
     loginType() {
       const u = this._currentHiveUser
@@ -920,12 +921,16 @@ export const useStoreUser = defineStore("useStoreUser", {
      */
     apiTokenSet(hiveAccname = this.currentUser) {
       console.debug("Setting API Token for", hiveAccname)
-      const token =
-        this.accessTokens[hiveAccname] || this.users[hiveAccname]?.apiToken
+      // Only use a token that is specifically for this account.
+      // Do not leak a token that was restored for a different cookie owner.
+      const token = this.accessTokens[hiveAccname]
       if (token) {
         apiLogin.defaults.headers.common["Authorization"] = `Bearer ${token}`
         return true
       }
+      // Clear the header if we have no token for this specific user
+      // (prevents sending the wrong user's token after a switch).
+      delete apiLogin.defaults.headers.common["Authorization"]
       return false
     },
 


### PR DESCRIPTION
- Added lastCookieRestore tracking in store state.
- In ensureAccessToken: if we recently tried for a target account and the active browser cookie restored a *different* owner, skip the network call for 30s. This stops the repeated /auth/refresh spam for webauthn accounts (like v4vapp-test) when another account's cookie is currently active in the browser.
- Still allows the first attempt and respects the existing in-flight dedup.

This directly addresses the log spam and extra backend load the user reported.